### PR TITLE
Fix memset import.

### DIFF
--- a/lib/app.cc
+++ b/lib/app.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cstring>
 
 #include "app.hh"
 #include "config.hh"


### PR DESCRIPTION
This line errored when I tried to update, removing the `std::` seems to have fixed it.